### PR TITLE
Fix Iron Prestige Colours

### DIFF
--- a/src/main/java/com/strawberry/statsify/Statsify.java
+++ b/src/main/java/com/strawberry/statsify/Statsify.java
@@ -838,7 +838,7 @@ Prename check end
         }
 
         if (Stars >= 100 && Stars < 200) {
-            color = "\u00a7b";
+            color = "\u00A7f";
             return color + text + "\u272b";
         }
         if (Stars >= 200 && Stars < 300) {


### PR DESCRIPTION
Make iron prestige star colour white, right now it just looks like diamond prestige.